### PR TITLE
Allow configuring direct debit service level

### DIFF
--- a/src/main/java/org/openknowledgehub/data/directdebit/DirectDebitDocumentBuilder.java
+++ b/src/main/java/org/openknowledgehub/data/directdebit/DirectDebitDocumentBuilder.java
@@ -37,6 +37,8 @@ public class DirectDebitDocumentBuilder {
 
   private List<DirectDebitPayment> payments;
 
+  private String serviceLevel = DirectDebitDocumentData.DEFAULT_SERVICE_LEVEL;
+
   private DirectDebitDocumentBuilder() {}
 
   public static DirectDebitDocumentBuilder create(String messageId) {
@@ -78,7 +80,21 @@ public class DirectDebitDocumentBuilder {
     return this;
   }
 
+  public DirectDebitDocumentBuilder withServiceLevel(String serviceLevel) {
+    if (Objects.isNull(serviceLevel)) {
+      throw new JSepaValidationException("'serviceLevel' cannot be null");
+    }
+
+    if (serviceLevel.isBlank()) {
+      throw new JSepaValidationException("'serviceLevel' cannot be empty");
+    }
+
+    this.serviceLevel = serviceLevel;
+
+    return this;
+  }
+
   public DirectDebitDocumentData build() {
-    return new DirectDebitDocumentData(messageId, creditor, payments);
+    return new DirectDebitDocumentData(messageId, creditor, payments, serviceLevel);
   }
 }

--- a/src/main/java/org/openknowledgehub/data/directdebit/DirectDebitDocumentData.java
+++ b/src/main/java/org/openknowledgehub/data/directdebit/DirectDebitDocumentData.java
@@ -26,6 +26,7 @@ import org.openknowledgehub.data.SepaXmlDocument;
 import org.openknowledgehub.data.common.AccountIdentification;
 import org.openknowledgehub.data.configuration.LocalDateTimeAdapter;
 import org.openknowledgehub.exception.JSepaValidationException;
+import org.openknowledgehub.util.JSepaContentSanitizer;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
@@ -57,6 +58,11 @@ public class DirectDebitDocumentData implements SepaXmlDocument {
   @XmlElement(name = "Payment")
   private final List<DirectDebitPayment> payments;
 
+  @XmlElement(name = "ServiceLevel")
+  private final String serviceLevel;
+
+  static final String DEFAULT_SERVICE_LEVEL = "CORE";
+
   /** Default constructor for JAX-B only. You should no used programmatically */
   public DirectDebitDocumentData() {
     this.creationTime = null;
@@ -64,10 +70,19 @@ public class DirectDebitDocumentData implements SepaXmlDocument {
     this.creditor = null;
     this.payments = null;
     this.paymentMethod = null;
+    this.serviceLevel = null;
   }
 
   public DirectDebitDocumentData(
       String messageId, AccountIdentification creditor, List<DirectDebitPayment> payments) {
+    this(messageId, creditor, payments, DEFAULT_SERVICE_LEVEL);
+  }
+
+  public DirectDebitDocumentData(
+      String messageId,
+      AccountIdentification creditor,
+      List<DirectDebitPayment> payments,
+      String serviceLevel) {
 
     if (Objects.isNull(messageId)) {
       throw new JSepaValidationException("DirectDebitDocumentData 'messageId' cannot be null");
@@ -81,11 +96,23 @@ public class DirectDebitDocumentData implements SepaXmlDocument {
       throw new JSepaValidationException("DirectDebitDocumentData 'payments' cannot be null");
     }
 
+    if (Objects.isNull(serviceLevel)) {
+      throw new JSepaValidationException("DirectDebitDocumentData 'serviceLevel' cannot be null");
+    }
+
+    String sanitizedServiceLevel =
+        JSepaContentSanitizer.of(serviceLevel).withMaxLength(4).sanitize().toUpperCase();
+
+    if (sanitizedServiceLevel.isBlank()) {
+      throw new JSepaValidationException("DirectDebitDocumentData 'serviceLevel' cannot be empty");
+    }
+
     this.creationTime = LocalDateTime.now();
     this.messageId = messageId;
     this.creditor = creditor;
     this.payments = payments;
     this.paymentMethod = "DD";
+    this.serviceLevel = sanitizedServiceLevel;
   }
 
   public LocalDateTime getCreationTime() {
@@ -108,6 +135,10 @@ public class DirectDebitDocumentData implements SepaXmlDocument {
     return paymentMethod;
   }
 
+  public String getServiceLevel() {
+    return serviceLevel;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (o == null || getClass() != o.getClass()) return false;
@@ -116,12 +147,13 @@ public class DirectDebitDocumentData implements SepaXmlDocument {
         && Objects.equals(paymentMethod, that.paymentMethod)
         && Objects.equals(messageId, that.messageId)
         && Objects.equals(creditor, that.creditor)
-        && Objects.equals(payments, that.payments);
+        && Objects.equals(payments, that.payments)
+        && Objects.equals(serviceLevel, that.serviceLevel);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(creationTime, paymentMethod, messageId, creditor, payments);
+    return Objects.hash(creationTime, paymentMethod, messageId, creditor, payments, serviceLevel);
   }
 
   @Override
@@ -131,6 +163,9 @@ public class DirectDebitDocumentData implements SepaXmlDocument {
         + creationTime
         + ", messageId='"
         + messageId
+        + '\''
+        + ", serviceLevel='"
+        + serviceLevel
         + '\''
         + '}';
   }

--- a/src/main/resources/transform/transform_pain.008.001.11.xslt
+++ b/src/main/resources/transform/transform_pain.008.001.11.xslt
@@ -87,7 +87,9 @@
                             </PmtId>
                             <PmtTpInf>
                                 <SvcLvl>
-                                    <Cd>CORE</Cd>
+                                    <Cd>
+                                        <xsl:value-of select="/DirectDebitDocumentData/ServiceLevel"/>
+                                    </Cd>
                                 </SvcLvl>
                                 <LclInstrm>
                                     <Cd>CORE</Cd>

--- a/src/test/java/org/openknowledgehub/api/assertions/DirectDebitDocumentDataAssert.java
+++ b/src/test/java/org/openknowledgehub/api/assertions/DirectDebitDocumentDataAssert.java
@@ -20,6 +20,7 @@ public class DirectDebitDocumentDataAssert
     assertThat(actual.getCreditor()).isNull();
     assertThat(actual.getPayments()).isNull();
     assertThat(actual.getPaymentMethod()).isNull();
+    assertThat(actual.getServiceLevel()).isNull();
 
     return this;
   }
@@ -33,6 +34,12 @@ public class DirectDebitDocumentDataAssert
   public DirectDebitDocumentDataAssert hasCreationTimeCloseToNow() {
     assertThat(actual.getCreationTime())
         .isCloseTo(LocalDateTime.now(), new TemporalUnitWithinOffset(500, ChronoUnit.MILLIS));
+
+    return this;
+  }
+
+  public DirectDebitDocumentDataAssert hasServiceLevel(String expectedServiceLevel) {
+    assertThat(actual.getServiceLevel()).isEqualTo(expectedServiceLevel);
 
     return this;
   }

--- a/src/test/java/org/openknowledgehub/data/directdebit/DirectDebitDocumentBuilderTest.java
+++ b/src/test/java/org/openknowledgehub/data/directdebit/DirectDebitDocumentBuilderTest.java
@@ -61,6 +61,9 @@ class DirectDebitDocumentBuilderTest {
     jSepaAssertThat(createdDirectDebitDocumentData.getPayments().get(0))
         .isNotNull()
         .hasDefaultTestValues();
+
+    assertThat(createdDirectDebitDocumentData.getServiceLevel())
+        .isEqualTo(DirectDebitDocumentData.DEFAULT_SERVICE_LEVEL);
   }
 
   @Test
@@ -97,5 +100,38 @@ class DirectDebitDocumentBuilderTest {
     assertThatThrownBy(() -> builder.addPayment(null))
         .isInstanceOf(JSepaValidationException.class)
         .hasMessage("'paymentBuilder' cannot be null");
+  }
+
+  @Test
+  @DisplayName("Should allow to customize the service level")
+  void testCreateWithCustomServiceLevel() {
+    final var createdDirectDebitDocumentData =
+        DirectDebitDocumentBuilder.create(MESSAGE_IDENTIFICATION)
+            .withCreditor(accountIdentification().defaultAccount())
+            .withServiceLevel("SEPA")
+            .addPayment(directDebit().payment().defaultBuilder())
+            .build();
+
+    assertThat(createdDirectDebitDocumentData.getServiceLevel()).isEqualTo("SEPA");
+  }
+
+  @Test
+  @DisplayName("Should not allow null service level")
+  void testCreateWithNullServiceLevel() {
+    DirectDebitDocumentBuilder builder = DirectDebitDocumentBuilder.create(MESSAGE_IDENTIFICATION);
+
+    assertThatThrownBy(() -> builder.withServiceLevel(null))
+        .isInstanceOf(JSepaValidationException.class)
+        .hasMessage("'serviceLevel' cannot be null");
+  }
+
+  @Test
+  @DisplayName("Should not allow empty service level")
+  void testCreateWithEmptyServiceLevel() {
+    DirectDebitDocumentBuilder builder = DirectDebitDocumentBuilder.create(MESSAGE_IDENTIFICATION);
+
+    assertThatThrownBy(() -> builder.withServiceLevel("   "))
+        .isInstanceOf(JSepaValidationException.class)
+        .hasMessage("'serviceLevel' cannot be empty");
   }
 }

--- a/src/test/java/org/openknowledgehub/data/directdebit/DirectDebitDocumentDataTest.java
+++ b/src/test/java/org/openknowledgehub/data/directdebit/DirectDebitDocumentDataTest.java
@@ -54,7 +54,8 @@ class DirectDebitDocumentDataTest {
     jSepaAssertThat(createdDirectDebitDocumentData)
         .isNotNull()
         .hasMessageId(MESSAGE_IDENTIFICATION)
-        .hasCreationTimeCloseToNow();
+        .hasCreationTimeCloseToNow()
+        .hasServiceLevel(DirectDebitDocumentData.DEFAULT_SERVICE_LEVEL);
 
     jSepaAssertThat(createdDirectDebitDocumentData.getCreditor())
         .isNotNull()
@@ -73,6 +74,21 @@ class DirectDebitDocumentDataTest {
     final var createdDirectDebitDocumentData = new DirectDebitDocumentData();
 
     jSepaAssertThat(createdDirectDebitDocumentData).isNotNull().isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should create a DirectDebitDocumentData with custom service level")
+  void testCreateWithCustomServiceLevel() {
+    final var createdDirectDebitDocumentData =
+        new DirectDebitDocumentData(
+            MESSAGE_IDENTIFICATION,
+            accountIdentification().defaultAccount(),
+            Collections.singletonList(directDebit().payment().defaultPayment()),
+            "sepa");
+
+    jSepaAssertThat(createdDirectDebitDocumentData)
+        .isNotNull()
+        .hasServiceLevel("SEPA");
   }
 
   @ParameterizedTest
@@ -107,5 +123,33 @@ class DirectDebitDocumentDataTest {
             accountIdentification().defaultAccount(),
             null,
             "DirectDebitDocumentData 'payments' cannot be null"));
+  }
+
+  @Test
+  @DisplayName("Should not allow null service level")
+  void testCreateWithNullServiceLevel() {
+    assertThatThrownBy(
+            () ->
+                new DirectDebitDocumentData(
+                    MESSAGE_IDENTIFICATION,
+                    accountIdentification().defaultAccount(),
+                    Collections.singletonList(directDebit().payment().defaultPayment()),
+                    null))
+        .isInstanceOf(JSepaValidationException.class)
+        .hasMessage("DirectDebitDocumentData 'serviceLevel' cannot be null");
+  }
+
+  @Test
+  @DisplayName("Should not allow empty service level")
+  void testCreateWithEmptyServiceLevel() {
+    assertThatThrownBy(
+            () ->
+                new DirectDebitDocumentData(
+                    MESSAGE_IDENTIFICATION,
+                    accountIdentification().defaultAccount(),
+                    Collections.singletonList(directDebit().payment().defaultPayment()),
+                    "   "))
+        .isInstanceOf(JSepaValidationException.class)
+        .hasMessage("DirectDebitDocumentData 'serviceLevel' cannot be empty");
   }
 }

--- a/src/test/java/org/openknowledgehub/transformer/sepa/DirectDebitTransformerTest.java
+++ b/src/test/java/org/openknowledgehub/transformer/sepa/DirectDebitTransformerTest.java
@@ -1,8 +1,10 @@
 package org.openknowledgehub.transformer.sepa;
 
 import static org.openknowledgehub.api.assertions.JSepaAssertions.jSepaAssertThat;
+import static org.openknowledgehub.api.objects.DirectDebitTestProvider.MESSAGE_IDENTIFICATION;
 
 import org.openknowledgehub.api.objects.TestObjects;
+import org.openknowledgehub.data.directdebit.DirectDebitDocumentBuilder;
 import org.openknowledgehub.data.directdebit.DirectDebitDocumentData;
 import org.openknowledgehub.transformer.JSepaTransformer;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,5 +28,20 @@ class DirectDebitTransformerTest {
         underTest.transform(TestObjects.directDebit().document().defaultDocument());
 
     jSepaAssertThat(transformedXml).isNotNull().isInAValidDirectDebitShape();
+  }
+
+  @Test
+  @DisplayName("Should map the configured service level")
+  void testTransformWithCustomServiceLevel() {
+    final var directDebitDocumentData =
+        DirectDebitDocumentBuilder.create(MESSAGE_IDENTIFICATION)
+            .withCreditor(TestObjects.accountIdentification().defaultAccount())
+            .withServiceLevel("SEPA")
+            .addPayment(TestObjects.directDebit().payment().defaultBuilder())
+            .build();
+
+    final var transformedXml = underTest.transform(directDebitDocumentData);
+
+    jSepaAssertThat(transformedXml).contains("<SvcLvl>").contains("<Cd>SEPA</Cd>");
   }
 }


### PR DESCRIPTION
## Summary
- add a configurable service level to direct debit document data with a default of CORE to preserve backwards compatibility
- expose a builder API to override the service level and feed it into the pain.008 transform
- expand assertions, unit tests, and transformer tests to cover the new service level behaviour

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68d658a93a848329984459d612f50e15