### PR TITLE
Add optional pain.008.001.02 transformer for direct debit

### DIFF
--- a/src/main/java/org/openknowledgehub/transformer/sepa/DirectDebitTransformer.java
+++ b/src/main/java/org/openknowledgehub/transformer/sepa/DirectDebitTransformer.java
@@ -22,12 +22,22 @@
 
 package org.openknowledgehub.transformer.sepa;
 
+import java.util.Objects;
+
 import org.openknowledgehub.data.directdebit.DirectDebitDocumentData;
 
 public final class DirectDebitTransformer
     extends AbstractJSepaTransformer<DirectDebitDocumentData> {
 
-  private static final String XSLT_PAIN_008_001_11 = "/transform/transform_pain.008.001.11.xslt";
+  private final String xsltFileName;
+
+  public DirectDebitTransformer() {
+    this(Version.PAIN_008_001_11);
+  }
+
+  public DirectDebitTransformer(Version version) {
+    this.xsltFileName = Objects.requireNonNull(version, "version").xsltFileName;
+  }
 
   @Override
   protected Class<DirectDebitDocumentData> getSepaDocumentType() {
@@ -36,6 +46,17 @@ public final class DirectDebitTransformer
 
   @Override
   protected String getXsltFileName() {
-    return XSLT_PAIN_008_001_11;
+    return xsltFileName;
+  }
+
+  public enum Version {
+    PAIN_008_001_11("/transform/transform_pain.008.001.11.xslt"),
+    PAIN_008_001_02("/transform/transform_pain.008.001.02.xslt");
+
+    private final String xsltFileName;
+
+    Version(String xsltFileName) {
+      this.xsltFileName = xsltFileName;
+    }
   }
 }

--- a/src/main/resources/transform/transform_pain.008.001.02.xslt
+++ b/src/main/resources/transform/transform_pain.008.001.02.xslt
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2025 openknowledgehub.org
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+  ~ and associated documentation files (the “Software”), to deal in the Software without restriction,
+  ~ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+  ~ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all copies or
+  ~ substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  ~ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+  ~ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+  ~ AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  ~ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.001.02">
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:template match="/">
+        <Document>
+            <CstmrDrctDbtInitn>
+                <GrpHdr>
+                    <MsgId>
+                        <xsl:value-of select="/DirectDebitDocumentData/MessageId"/>
+                    </MsgId>
+                    <CreDtTm>
+                        <xsl:value-of select="/DirectDebitDocumentData/CreationDateTime"/>
+                    </CreDtTm>
+                    <NbOfTxs>
+                        <xsl:value-of select="count(/DirectDebitDocumentData/Payments/Payment)"/>
+                    </NbOfTxs>
+                    <CtrlSum>
+                        <xsl:value-of select="sum(/DirectDebitDocumentData/Payments/Payment/Amount)"/>
+                    </CtrlSum>
+                    <InitgPty>
+                        <Nm>
+                            <xsl:value-of select="/DirectDebitDocumentData/Creditor/Name"/>
+                        </Nm>
+                    </InitgPty>
+                </GrpHdr>
+                <xsl:for-each select="/DirectDebitDocumentData/Payments/Payment">
+                    <PmtInf>
+                        <PmtInfId>
+                            <xsl:value-of select="Identification"/>
+                        </PmtInfId>
+                        <PmtMtd>
+                            <xsl:value-of select="/DirectDebitDocumentData/PaymentMethod"/>
+                        </PmtMtd>
+                        <ReqdColltnDt>
+                            <xsl:value-of select="DirectDebitDueAt"/>
+                        </ReqdColltnDt>
+                        <Cdtr>
+                            <Nm>
+                                <xsl:value-of select="/DirectDebitDocumentData/Creditor/Name"/>
+                            </Nm>
+                        </Cdtr>
+                        <CdtrAcct>
+                            <Id>
+                                <IBAN>
+                                    <xsl:value-of select="/DirectDebitDocumentData/Creditor/Iban"/>
+                                </IBAN>
+                            </Id>
+                        </CdtrAcct>
+                        <CdtrAgt>
+                            <FinInstnId>
+                                <BIC>
+                                    <xsl:value-of select="/DirectDebitDocumentData/Creditor/Bic"/>
+                                </BIC>
+                            </FinInstnId>
+                        </CdtrAgt>
+                        <DrctDbtTxInf>
+                            <PmtId>
+                                <EndToEndId>
+                                    <xsl:value-of select="Mandate/Identification"/>
+                                </EndToEndId>
+                            </PmtId>
+                            <PmtTpInf>
+                                <SvcLvl>
+                                    <Cd>
+                                        <xsl:value-of select="/DirectDebitDocumentData/ServiceLevel"/>
+                                    </Cd>
+                                </SvcLvl>
+                                <LclInstrm>
+                                    <Cd>CORE</Cd>
+                                </LclInstrm>
+                                <SeqTp>
+                                    <xsl:value-of select="Mandate/Type"/>
+                                </SeqTp>
+                            </PmtTpInf>
+                            <InstdAmt Ccy="">
+                                <xsl:attribute name="Ccy">
+                                    <xsl:value-of select="Currency"/>
+                                </xsl:attribute>
+                                <xsl:value-of select="Amount"/>
+                            </InstdAmt>
+                            <DrctDbtTx>
+                                <MndtRltdInf>
+                                    <MndtId>
+                                        <xsl:value-of select="Mandate/Identification"/>
+                                    </MndtId>
+                                    <DtOfSgntr>
+                                        <xsl:value-of select="Mandate/IssuedAt"/>
+                                    </DtOfSgntr>
+                                </MndtRltdInf>
+                                <CdtrSchmeId>
+                                    <Id>
+                                        <PrvtId>
+                                            <Othr>
+                                                <Id>
+                                                    <xsl:value-of select="/DirectDebitDocumentData/Creditor/Identifier"/>
+                                                </Id>
+                                            </Othr>
+                                        </PrvtId>
+                                    </Id>
+                                </CdtrSchmeId>
+                            </DrctDbtTx>
+                            <DbtrAgt>
+                                <FinInstnId>
+                                    <BIC>
+                                        <xsl:value-of select="Debitor/Bic"/>
+                                    </BIC>
+                                </FinInstnId>
+                            </DbtrAgt>
+                            <Dbtr>
+                                <Nm>
+                                    <xsl:value-of select="Debitor/Name"/>
+                                </Nm>
+                            </Dbtr>
+                            <DbtrAcct>
+                                <Id>
+                                    <IBAN>
+                                        <xsl:value-of select="Debitor/Iban"/>
+                                    </IBAN>
+                                </Id>
+                            </DbtrAcct>
+                            <xsl:if test="ReasonForPayment">
+                                <RmtInf>
+                                    <Ustrd>
+                                        <xsl:value-of select="ReasonForPayment"/>
+                                    </Ustrd>
+                                </RmtInf>
+                            </xsl:if>
+                        </DrctDbtTxInf>
+                    </PmtInf>
+                </xsl:for-each>
+            </CstmrDrctDbtInitn>
+        </Document>
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/test/java/org/openknowledgehub/transformer/sepa/DirectDebitTransformerTest.java
+++ b/src/test/java/org/openknowledgehub/transformer/sepa/DirectDebitTransformerTest.java
@@ -1,5 +1,6 @@
 package org.openknowledgehub.transformer.sepa;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openknowledgehub.api.assertions.JSepaAssertions.jSepaAssertThat;
 import static org.openknowledgehub.api.objects.DirectDebitTestProvider.MESSAGE_IDENTIFICATION;
 
@@ -43,5 +44,18 @@ class DirectDebitTransformerTest {
     final var transformedXml = underTest.transform(directDebitDocumentData);
 
     jSepaAssertThat(transformedXml).contains("<SvcLvl>").contains("<Cd>SEPA</Cd>");
+  }
+
+  @Test
+  @DisplayName("Should transform using pain.008.001.02 template")
+  void testTransformPain00800102() {
+    final var transformedXml =
+        new DirectDebitTransformer(DirectDebitTransformer.Version.PAIN_008_001_02)
+            .transform(TestObjects.directDebit().document().defaultDocument());
+
+    assertThat(transformedXml)
+        .contains("urn:iso:std:iso:20022:tech:xsd:pain.008.001.02")
+        .contains("<BIC>")
+        .doesNotContain("<BICFI>");
   }
 }


### PR DESCRIPTION
## Summary
- allow choosing the XSLT template used by `DirectDebitTransformer`
- add a pain.008.001.02 transformation template with legacy `BIC` tags
- cover the new template with an additional transformer unit test

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68d72232c9a08329a69eefcdc379e86d