### PR TITLE
Align pain.008.001.02 template with legacy schema

### DIFF
--- a/src/main/java/org/openknowledgehub/transformer/sepa/DirectDebitTransformer.java
+++ b/src/main/java/org/openknowledgehub/transformer/sepa/DirectDebitTransformer.java
@@ -22,12 +22,22 @@
 
 package org.openknowledgehub.transformer.sepa;
 
+import java.util.Objects;
+
 import org.openknowledgehub.data.directdebit.DirectDebitDocumentData;
 
 public final class DirectDebitTransformer
     extends AbstractJSepaTransformer<DirectDebitDocumentData> {
 
-  private static final String XSLT_PAIN_008_001_11 = "/transform/transform_pain.008.001.11.xslt";
+  private final String xsltFileName;
+
+  public DirectDebitTransformer() {
+    this(Version.PAIN_008_001_11);
+  }
+
+  public DirectDebitTransformer(Version version) {
+    this.xsltFileName = Objects.requireNonNull(version, "version").xsltFileName;
+  }
 
   @Override
   protected Class<DirectDebitDocumentData> getSepaDocumentType() {
@@ -36,6 +46,17 @@ public final class DirectDebitTransformer
 
   @Override
   protected String getXsltFileName() {
-    return XSLT_PAIN_008_001_11;
+    return xsltFileName;
+  }
+
+  public enum Version {
+    PAIN_008_001_11("/transform/transform_pain.008.001.11.xslt"),
+    PAIN_008_001_02("/transform/transform_pain.008.001.02.xslt");
+
+    private final String xsltFileName;
+
+    Version(String xsltFileName) {
+      this.xsltFileName = xsltFileName;
+    }
   }
 }

--- a/src/main/resources/transform/transform_pain.008.001.02.xslt
+++ b/src/main/resources/transform/transform_pain.008.001.02.xslt
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2025 openknowledgehub.org
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+  ~ and associated documentation files (the “Software”), to deal in the Software without restriction,
+  ~ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+  ~ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all copies or
+  ~ substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  ~ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+  ~ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+  ~ AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  ~ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.001.02">
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:template match="/">
+        <Document>
+            <CstmrDrctDbtInitn>
+                <GrpHdr>
+                    <MsgId>
+                        <xsl:value-of select="/DirectDebitDocumentData/MessageId"/>
+                    </MsgId>
+                    <CreDtTm>
+                        <xsl:value-of select="/DirectDebitDocumentData/CreationDateTime"/>
+                    </CreDtTm>
+                    <NbOfTxs>
+                        <xsl:value-of select="count(/DirectDebitDocumentData/Payments/Payment)"/>
+                    </NbOfTxs>
+                    <CtrlSum>
+                        <xsl:value-of select="sum(/DirectDebitDocumentData/Payments/Payment/Amount)"/>
+                    </CtrlSum>
+                    <InitgPty>
+                        <Nm>
+                            <xsl:value-of select="/DirectDebitDocumentData/Creditor/Name"/>
+                        </Nm>
+                    </InitgPty>
+                </GrpHdr>
+                <xsl:variable name="payments" select="/DirectDebitDocumentData/Payments/Payment"/>
+                <xsl:variable name="firstPayment" select="$payments[1]"/>
+                <PmtInf>
+                    <PmtInfId>
+                        <xsl:value-of select="$firstPayment/Identification"/>
+                    </PmtInfId>
+                    <PmtMtd>
+                        <xsl:value-of select="/DirectDebitDocumentData/PaymentMethod"/>
+                    </PmtMtd>
+                    <BtchBookg>true</BtchBookg>
+                    <NbOfTxs>
+                        <xsl:value-of select="count($payments)"/>
+                    </NbOfTxs>
+                    <CtrlSum>
+                        <xsl:value-of select="sum($payments/Amount)"/>
+                    </CtrlSum>
+                    <PmtTpInf>
+                        <SvcLvl>
+                            <Cd>
+                                <xsl:value-of select="/DirectDebitDocumentData/ServiceLevel"/>
+                            </Cd>
+                        </SvcLvl>
+                        <LclInstrm>
+                            <Cd>CORE</Cd>
+                        </LclInstrm>
+                        <SeqTp>
+                            <xsl:value-of select="$firstPayment/Mandate/Type"/>
+                        </SeqTp>
+                    </PmtTpInf>
+                    <ReqdColltnDt>
+                        <xsl:value-of select="$firstPayment/DirectDebitDueAt"/>
+                    </ReqdColltnDt>
+                    <Cdtr>
+                        <Nm>
+                            <xsl:value-of select="/DirectDebitDocumentData/Creditor/Name"/>
+                        </Nm>
+                    </Cdtr>
+                    <CdtrAcct>
+                        <Id>
+                            <IBAN>
+                                <xsl:value-of select="/DirectDebitDocumentData/Creditor/Iban"/>
+                            </IBAN>
+                        </Id>
+                    </CdtrAcct>
+                    <CdtrAgt>
+                        <FinInstnId>
+                            <BIC>
+                                <xsl:value-of select="/DirectDebitDocumentData/Creditor/Bic"/>
+                            </BIC>
+                        </FinInstnId>
+                    </CdtrAgt>
+                    <ChrgBr>SLEV</ChrgBr>
+                    <CdtrSchmeId>
+                        <Id>
+                            <PrvtId>
+                                <Othr>
+                                    <Id>
+                                        <xsl:value-of select="/DirectDebitDocumentData/Creditor/Identifier"/>
+                                    </Id>
+                                    <SchmeNm>
+                                        <Prtry>SEPA</Prtry>
+                                    </SchmeNm>
+                                </Othr>
+                            </PrvtId>
+                        </Id>
+                    </CdtrSchmeId>
+                    <xsl:for-each select="$payments">
+                        <DrctDbtTxInf>
+                            <PmtId>
+                                <EndToEndId>
+                                    <xsl:value-of select="Mandate/Identification"/>
+                                </EndToEndId>
+                            </PmtId>
+                            <InstdAmt Ccy="">
+                                <xsl:attribute name="Ccy">
+                                    <xsl:value-of select="Currency"/>
+                                </xsl:attribute>
+                                <xsl:value-of select="Amount"/>
+                            </InstdAmt>
+                            <DrctDbtTx>
+                                <MndtRltdInf>
+                                    <MndtId>
+                                        <xsl:value-of select="Mandate/Identification"/>
+                                    </MndtId>
+                                    <DtOfSgntr>
+                                        <xsl:value-of select="Mandate/IssuedAt"/>
+                                    </DtOfSgntr>
+                                </MndtRltdInf>
+                            </DrctDbtTx>
+                            <DbtrAgt>
+                                <FinInstnId>
+                                    <BIC>
+                                        <xsl:value-of select="Debitor/Bic"/>
+                                    </BIC>
+                                </FinInstnId>
+                            </DbtrAgt>
+                            <Dbtr>
+                                <Nm>
+                                    <xsl:value-of select="Debitor/Name"/>
+                                </Nm>
+                            </Dbtr>
+                            <DbtrAcct>
+                                <Id>
+                                    <IBAN>
+                                        <xsl:value-of select="Debitor/Iban"/>
+                                    </IBAN>
+                                </Id>
+                            </DbtrAcct>
+                            <xsl:if test="ReasonForPayment">
+                                <RmtInf>
+                                    <Ustrd>
+                                        <xsl:value-of select="ReasonForPayment"/>
+                                    </Ustrd>
+                                </RmtInf>
+                            </xsl:if>
+                        </DrctDbtTxInf>
+                    </xsl:for-each>
+                </PmtInf>
+            </CstmrDrctDbtInitn>
+        </Document>
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/test/java/org/openknowledgehub/transformer/sepa/DirectDebitTransformerTest.java
+++ b/src/test/java/org/openknowledgehub/transformer/sepa/DirectDebitTransformerTest.java
@@ -1,12 +1,19 @@
 package org.openknowledgehub.transformer.sepa;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openknowledgehub.api.assertions.JSepaAssertions.jSepaAssertThat;
+import static org.openknowledgehub.api.objects.DirectDebitTestProvider.DirectDebitPaymentTestProvider.AMOUNT;
+import static org.openknowledgehub.api.objects.DirectDebitTestProvider.DirectDebitPaymentTestProvider.DUE_AT;
 import static org.openknowledgehub.api.objects.DirectDebitTestProvider.MESSAGE_IDENTIFICATION;
 
+import org.openknowledgehub.api.objects.MandateTestProvider;
 import org.openknowledgehub.api.objects.TestObjects;
 import org.openknowledgehub.data.directdebit.DirectDebitDocumentBuilder;
 import org.openknowledgehub.data.directdebit.DirectDebitDocumentData;
+import org.openknowledgehub.data.directdebit.MandateBuilder;
+import org.openknowledgehub.data.directdebit.MandateType;
 import org.openknowledgehub.transformer.JSepaTransformer;
+import java.math.BigDecimal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,5 +50,58 @@ class DirectDebitTransformerTest {
     final var transformedXml = underTest.transform(directDebitDocumentData);
 
     jSepaAssertThat(transformedXml).contains("<SvcLvl>").contains("<Cd>SEPA</Cd>");
+  }
+
+  @Test
+  @DisplayName("Should transform using pain.008.001.02 template")
+  void testTransformPain00800102() {
+    final var transformedXml =
+        new DirectDebitTransformer(DirectDebitTransformer.Version.PAIN_008_001_02)
+            .transform(TestObjects.directDebit().document().defaultDocument());
+
+    assertThat(transformedXml)
+        .contains("urn:iso:std:iso:20022:tech:xsd:pain.008.001.02")
+        .contains("<BIC>")
+        .contains("<BtchBookg>true</BtchBookg>")
+        .contains("<ChrgBr>SLEV</ChrgBr>")
+        .containsOnlyOnce("<PmtInf>")
+        .doesNotContain("<BICFI>");
+  }
+
+  @Test
+  @DisplayName("Should group multiple direct debit transactions within a single PmtInf for pain.008.001.02")
+  void testTransformPain00800102MultiplePayments() {
+    final var secondPaymentBuilder =
+        TestObjects.directDebit()
+            .payment()
+            .defaultBuilder()
+            .withIdentification("second-payment")
+            .withAmount(BigDecimal.valueOf(7.89))
+            .withDirectDebitDueAt(DUE_AT.plusDays(1))
+            .withMandate(
+                MandateBuilder.withMandate("second-mandate")
+                    .withMandateIssuedAt(MandateTestProvider.ISSUED_AT.plusDays(5))
+                    .withMandateType(MandateType.RECURRING)
+                    .build());
+
+    final var document =
+        DirectDebitDocumentBuilder.create(MESSAGE_IDENTIFICATION)
+            .withCreditor(TestObjects.accountIdentification().defaultAccount())
+            .addPayment(TestObjects.directDebit().payment().defaultBuilder())
+            .addPayment(secondPaymentBuilder)
+            .build();
+
+    final var transformedXml =
+        new DirectDebitTransformer(DirectDebitTransformer.Version.PAIN_008_001_02)
+            .transform(document);
+
+    final var expectedCtrlSum = AMOUNT.add(BigDecimal.valueOf(7.89)).toPlainString();
+
+    assertThat(transformedXml)
+        .containsOnlyOnce("<PmtInf>")
+        .contains("<NbOfTxs>2</NbOfTxs>")
+        .contains("<CtrlSum>" + expectedCtrlSum + "</CtrlSum>")
+        .contains("second-mandate")
+        .contains("MandateId");
   }
 }


### PR DESCRIPTION
## Summary
- update the pain.008.001.02 XSLT to emit a single PmtInf block with aggregated totals and creditor scheme information while looping at the DrctDbtTxInf level
- add regression coverage ensuring the legacy template includes batch booking fields and keeps multiple transactions within one payment info block

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68d72232c9a08329a69eefcdc379e86d